### PR TITLE
Process asset path as a template

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -49,7 +49,7 @@ module.exports = async (pluginConfig, context) => {
 
   await Promise.all(
     globbedAssets.map(async asset => {
-      const filePath = isPlainObject(asset) ? asset.path : asset;
+      const filePath = template(isPlainObject(asset) ? asset.path : asset)(context);
       const fullFilePath = resolve(cwd, filePath);
       let file;
 


### PR DESCRIPTION
Now it is impossible to use placeholders like `nextRelease.version`, `nextRelease.gitTag` inside asset path. :-(
Something like this:
```javascript
const releaseArchiveFileName = "version-${nextRelease.version}.tar.gz"
```
and further on:
```javascript
        [
          "@saithodev/semantic-release-gitea",
          {
            assets: [
              {
                path: `${releaseArchiveFileName}`,
                label: "Release version ${nextRelease.gitTag}",
              },
            ],
          },
        ]
```

This patch solves the problem.